### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ The smoothed model is added to a new layer(called Loop_subdiv_XXXX). The origina
 For the technical details see the Hoppes and co-workers paper: Piecewise Smooth Surface Reconstruction . This paper also describes how to do partial subdivision, using crease edges and darts, which are not yet implemented in this plugin.
 
 ##Known issues
-There are known issues with non-manifold meshes where adjacent faces do not share edges (try smoothing a captial E), I am looking for solutions. Also when smoothing components the face materials are lost in the smoothed object.
+There are known issues with non-manifold meshes where adjacent faces do not share edges (try smoothing a capital E), I am looking for solutions. Also when smoothing components the face materials are lost in the smoothed object.
 


### PR DESCRIPTION
@NB70, I've corrected a typographical error in the documentation of the [sketchup-loop-subdivision](https://github.com/NB70/sketchup-loop-subdivision) project. Specifically, I've changed captial to capital. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
